### PR TITLE
Run function on plugin load

### DIFF
--- a/nvm-auto-use.zsh
+++ b/nvm-auto-use.zsh
@@ -17,3 +17,4 @@ load-nvmrc() {
   fi
 }
 add-zsh-hook chpwd load-nvmrc
+load-nvmrc


### PR DESCRIPTION
I will confess up front that I am not a zsh or fig expert here, so there might be a better way to do this.

This plugin works great when changing directories ***after*** the terminal session has loaded. It would be helpful if it also ran when a terminal session is first initiated, like when code editors with built in terminals (ie. VS Code) default new terminal sessions to the directory the project is located in, which could contain an `.nvmrc` file. The nvm commands still need to be executed manually in this instance.